### PR TITLE
fix: update the hash function of txinfo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Description
+
+add a description of your changes here...
+
+### Rationale
+
+tell us why we need these changes...
+
+### Example
+
+add an example CLI or API response...
+
+### Changes
+
+Notable changes:
+* add each change in a bullet point here
+* ...

--- a/txutils/construct_tx.go
+++ b/txutils/construct_tx.go
@@ -12,7 +12,6 @@ import (
 
 	curve "github.com/bnb-chain/zkbnb-crypto/ecc/ztwistededwards/tebn254"
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
-	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	"github.com/bnb-chain/zkbnb-go-sdk/accounts"
 	"github.com/bnb-chain/zkbnb-go-sdk/types"
 )
@@ -25,7 +24,7 @@ func ConstructWithdrawTxInfo(key accounts.Signer, tx *types.WithdrawReq, ops *ty
 	}
 
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeWithdrawMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +48,7 @@ func ConstructRemoveLiquidityTx(key accounts.Signer, tx *types.RemoveLiquidityRe
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeRemoveLiquidityMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -74,7 +73,7 @@ func ConstructAddLiquidityTx(key accounts.Signer, tx *types.AddLiquidityReq, ops
 	}
 
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeAddLiquidityMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +97,7 @@ func ConstructSwapTx(key accounts.Signer, tx *types.SwapTxReq, ops *types.Transa
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeSwapMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -122,7 +121,7 @@ func ConstructTransferTx(key accounts.Signer, ops *types.TransactOpts, tx *types
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeTransferMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -146,7 +145,7 @@ func ConstructCreateCollectionTx(key accounts.Signer, tx *types.CreateCollection
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeCreateCollectionMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -170,7 +169,7 @@ func ConstructTransferNftTx(key accounts.Signer, tx *types.TransferNftTxReq, ops
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeTransferNftMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -194,7 +193,7 @@ func ConstructWithdrawNftTx(key accounts.Signer, tx *types.WithdrawNftTxReq, ops
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeWithdrawNftMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -218,7 +217,7 @@ func ConstructOfferTx(key accounts.Signer, tx *types.OfferTxInfo) (string, error
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeOfferMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -242,7 +241,7 @@ func ConstructMintNftTx(key accounts.Signer, tx *types.MintNftTxReq, ops *types.
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeMintNftMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -266,7 +265,7 @@ func ConstructAtomicMatchTx(key accounts.Signer, tx *types.AtomicMatchTxReq, ops
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeAtomicMatchMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}
@@ -290,7 +289,7 @@ func ConstructCancelOfferTx(key accounts.Signer, tx *types.CancelOfferReq, ops *
 		return "", err
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := legendTxTypes.ComputeCancelOfferMsgHash(convertedTx, hFunc)
+	msgHash, err := convertedTx.Hash(hFunc)
 	if err != nil {
 		return "", err
 	}

--- a/txutils/verify_tx_signature.go
+++ b/txutils/verify_tx_signature.go
@@ -229,7 +229,7 @@ func ConvertCancelOfferTxInfo(tx *types.CancelOfferReq, ops *types.TransactOpts)
 }
 
 func VerifyCancelOfferTxSig(pubKey string, tx *types.CancelOfferTxInfo) error {
-	message, err := legendTxTypes.ComputeCancelOfferMsgHash(tx, mimc.NewMiMC())
+	message, err := tx.Hash(mimc.NewMiMC())
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func VerifyCancelOfferTxSig(pubKey string, tx *types.CancelOfferTxInfo) error {
 }
 
 func VerifyWithdrawNftTxSig(pubKey string, tx *types.WithdrawNftTxInfo) error {
-	message, err := legendTxTypes.ComputeWithdrawNftMsgHash(tx, mimc.NewMiMC())
+	message, err := tx.Hash(mimc.NewMiMC())
 	if err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func VerifyWithdrawNftTxSig(pubKey string, tx *types.WithdrawNftTxInfo) error {
 }
 
 func VerifyTransferNftTxSig(pubKey string, tx *types.TransferNftTxInfo) error {
-	message, err := legendTxTypes.ComputeTransferNftMsgHash(tx, mimc.NewMiMC())
+	message, err := tx.Hash(mimc.NewMiMC())
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func VerifyTransferNftTxSig(pubKey string, tx *types.TransferNftTxInfo) error {
 
 func VerifyOfferTxSig(pubKey string, tx *types.OfferTxInfo) error {
 	convertedTx := ConvertOfferTxInfo(tx)
-	message, err := legendTxTypes.ComputeOfferMsgHash(convertedTx, mimc.NewMiMC())
+	message, err := convertedTx.Hash(mimc.NewMiMC())
 	if err != nil {
 		return err
 	}
@@ -314,7 +314,7 @@ func VerifyOfferTxSig(pubKey string, tx *types.OfferTxInfo) error {
 }
 
 func VerifyMintNftTxSig(pubKey string, tx *types.MintNftTxInfo) error {
-	message, err := legendTxTypes.ComputeMintNftMsgHash(tx, mimc.NewMiMC())
+	message, err := tx.Hash(mimc.NewMiMC())
 	if err != nil {
 		return err
 	}
@@ -335,7 +335,7 @@ func VerifyMintNftTxSig(pubKey string, tx *types.MintNftTxInfo) error {
 }
 
 func VerifyCreateCollectionTxSig(pubKey string, tx *types.CreateCollectionTxInfo) error {
-	message, err := legendTxTypes.ComputeCreateCollectionMsgHash(tx, mimc.NewMiMC())
+	message, err := tx.Hash(mimc.NewMiMC())
 	if err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func VerifyCreateCollectionTxSig(pubKey string, tx *types.CreateCollectionTxInfo
 }
 
 func VerifyAtomicMatchTxSig(pubKey string, tx *types.AtomicMatchTxInfo) error {
-	message, err := legendTxTypes.ComputeAtomicMatchMsgHash(tx, mimc.NewMiMC())
+	message, err := tx.Hash(mimc.NewMiMC())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
This PR is to fix the bug caused by the upgrade of dependency.

### Rationale
In the latest `zkbnb-crypto`, the hash function of txinfo have changed, this PR did the modification accordingly.

### Example
NA
### Changes

Notable changes:
NA