### PR TITLE
refactor: rename mempool tx to pending tx for l2

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -47,11 +47,11 @@ type ZkBNBQuerier interface {
 	// GetTxsByBlockHeight return txs in block
 	GetTxsByBlockHeight(blockHeight uint32) ([]*types.Tx, error)
 
-	// GetMempoolTxs returns the mempool txs
-	GetMempoolTxs(offset, limit uint32) (total uint32, txs []*types.Tx, err error)
+	// GetPendingTxs returns the pending txs
+	GetPendingTxs(offset, limit uint32) (total uint32, txs []*types.Tx, err error)
 
-	// GetMempoolTxsByAccountName returns the mempool txs by account name
-	GetMempoolTxsByAccountName(accountName string) (total uint32, txs []*types.Tx, err error)
+	// GetPendingTxsByAccountName returns the pending txs by account name
+	GetPendingTxsByAccountName(accountName string) (total uint32, txs []*types.Tx, err error)
 
 	// GetAccountByName returns account (mainly pubkey) by using account_name
 	GetAccountByName(accountName string) (*types.Account, error)

--- a/client/l2_client.go
+++ b/client/l2_client.go
@@ -521,9 +521,9 @@ func (c *l2Client) GetTx(hash string) (*types.EnrichedTx, error) {
 	return txResp, nil
 }
 
-func (c *l2Client) GetMempoolTxs(offset, limit uint32) (total uint32, txs []*types.Tx, err error) {
+func (c *l2Client) GetPendingTxs(offset, limit uint32) (total uint32, txs []*types.Tx, err error) {
 	resp, err := HttpClient.Get(c.endpoint +
-		fmt.Sprintf("/api/v1/mempoolTxs?offset=%d&limit=%d", offset, limit))
+		fmt.Sprintf("/api/v1/pendingTxs?offset=%d&limit=%d", offset, limit))
 	if err != nil {
 		return 0, nil, err
 	}
@@ -535,15 +535,15 @@ func (c *l2Client) GetMempoolTxs(offset, limit uint32) (total uint32, txs []*typ
 	if resp.StatusCode != http.StatusOK {
 		return 0, nil, fmt.Errorf(string(body))
 	}
-	txsResp := &types.MempoolTxs{}
+	txsResp := &types.Txs{}
 	if err := json.Unmarshal(body, txsResp); err != nil {
 		return 0, nil, err
 	}
-	return txsResp.Total, txsResp.MempoolTxs, nil
+	return txsResp.Total, txsResp.Txs, nil
 }
 
-func (c *l2Client) GetMempoolTxsByAccountName(accountName string) (total uint32, txs []*types.Tx, err error) {
-	resp, err := HttpClient.Get(c.endpoint + "/api/v1/accountMempoolTxs?by=account_name&value=" + accountName)
+func (c *l2Client) GetPendingTxsByAccountName(accountName string) (total uint32, txs []*types.Tx, err error) {
+	resp, err := HttpClient.Get(c.endpoint + "/api/v1/accountPendingTxs?by=account_name&value=" + accountName)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -555,11 +555,11 @@ func (c *l2Client) GetMempoolTxsByAccountName(accountName string) (total uint32,
 	if resp.StatusCode != http.StatusOK {
 		return 0, nil, fmt.Errorf(string(body))
 	}
-	txsResp := &types.MempoolTxs{}
+	txsResp := &types.Txs{}
 	if err := json.Unmarshal(body, txsResp); err != nil {
 		return 0, nil, err
 	}
-	return txsResp.Total, txsResp.MempoolTxs, nil
+	return txsResp.Total, txsResp.Txs, nil
 }
 
 func (c *l2Client) GetAccountByName(accountName string) (*types.Account, error) {

--- a/client/l2_client_test.go
+++ b/client/l2_client_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/bnb-chain/zkbnb-go-sdk/types"
 )
 
-var testEndpoint = "http://127.0.0.1:8888"
-var seed = "dc3543c9c912db587693f9b27e4d221c367772cc905cbb4b76c9f30050d2534c"
+var testEndpoint = "http://172.22.41.244:8888"
+var seed = "28e1a3762ff9944e9a4ad79477b756ef0aff3d2af76f0f40a0c3ec6ca76cf24b"
 
 func getSdkClient() *l2Client {
 	c := &l2Client{
@@ -357,7 +357,7 @@ func TestTransferInLayer2(t *testing.T) {
 	txInfo := types.TransferTxReq{
 		ToAccountName: "sher.legend",
 		AssetId:       0,
-		AssetAmount:   big.NewInt(1e17),
+		AssetAmount:   big.NewInt(1),
 	}
 	hash, err := l2Client.Transfer(&txInfo, nil)
 	assert.NoError(t, err)

--- a/client/l2_client_test.go
+++ b/client/l2_client_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/bnb-chain/zkbnb-go-sdk/types"
 )
 
-var testEndpoint = "http://172.22.41.244:8888"
-var seed = "28e1a3762ff9944e9a4ad79477b756ef0aff3d2af76f0f40a0c3ec6ca76cf24b"
+var testEndpoint = "http://127.0.0.1:8888"
+var seed = "dc3543c9c912db587693f9b27e4d221c367772cc905cbb4b76c9f30050d2534c"
 
 func getSdkClient() *l2Client {
 	c := &l2Client{

--- a/types/type.go
+++ b/types/type.go
@@ -178,11 +178,6 @@ type Txs struct {
 	Txs   []*Tx  `json:"txs"`
 }
 
-type MempoolTxs struct {
-	Total      uint32 `json:"total"`
-	MempoolTxs []*Tx  `json:"mempool_txs"`
-}
-
 type TxHash struct {
 	TxHash string `json:"tx_hash"`
 }


### PR DESCRIPTION
### Description

Update L2 client - renaming `MempoolTx` to `PendingTx`, which is required for the upstream changes.

### Rationale

Adapt apis.

### Example

NA

### Changes

Notable changes:
* please use `GetPendingTxs` instead of `GetMempoolTxs`