### PR TITLE
feat: update zkbnb-crypto dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bnb-chain/zkbnb-go-sdk
 go 1.18
 
 require (
-	github.com/bnb-chain/zkbnb-crypto v0.0.4-0.20220907124159-7d65ca88bff3
+	github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220907124239-7cdc9ddd1728
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/ethereum/go-ethereum v1.10.17
 	github.com/stretchr/testify v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/zkbnb-crypto v0.0.4-0.20220907124159-7d65ca88bff3 h1:ThJmaKhNn2My6FObNkXK6OeDLHzfmqBYmqJne1ptVGw=
-github.com/bnb-chain/zkbnb-crypto v0.0.4-0.20220907124159-7d65ca88bff3/go.mod h1:+JmfeD/50FbqIS8Fo4xgTDOM8nWIvfsfObQMAKv/7BU=
+github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220907124239-7cdc9ddd1728 h1:81nb+gHUkZlMasmWtOdW6rcUrdPWrb6Y8wLIbHeZ1Kk=
+github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220907124239-7cdc9ddd1728/go.mod h1:+JmfeD/50FbqIS8Fo4xgTDOM8nWIvfsfObQMAKv/7BU=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/btcd/btcec/v2 v2.1.2/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=


### PR DESCRIPTION
### Description

Update zkbnn-crypto version from `v0.0.4-0.20220907124159-7d65ca88bff3` to `v0.0.6-0.20220907124239-7cdc9ddd1728`

### Rationale

Old dependency of zkbnb-crypto is broken, need updates.

### Example

NA

### Changes

NA