### PR TITLE
api: remove price apis, add price fields in related apis

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -53,29 +53,23 @@ type ZkBNBQuerier interface {
 	// GetPendingTxsByAccountName returns the pending txs by account name
 	GetPendingTxsByAccountName(accountName string) (total uint32, txs []*types.Tx, err error)
 
-	// GetAccountByName returns account (mainly pubkey) by using account_name
+	// GetAccountByName returns account (mainly pubkey) by account name
 	GetAccountByName(accountName string) (*types.Account, error)
 
 	// GetAccounts returns accounts by query conditions
 	GetAccounts(offset, limit uint32) (*types.Accounts, error)
 
-	// GetAccountByPk returns account info by public key
+	// GetAccountByPk returns account by public key
 	GetAccountByPk(accountPk string) (*types.Account, error)
 
-	// GetAccountByIndex returns account info by account index
+	// GetAccountByIndex returns account by account index
 	GetAccountByIndex(accountIndex int64) (*types.Account, error)
 
 	// GetNextNonce returns nonce of account
-	GetNextNonce(accountIdx int64) (int64, error)
+	GetNextNonce(accountIndex int64) (int64, error)
 
 	// GetMaxOfferId returns max offer id for an account
 	GetMaxOfferId(accountIndex int64) (uint64, error)
-
-	// GetCurrencyPrice returns currency price by symbol
-	GetCurrencyPrice(symbol string) (*types.CurrencyPrice, error)
-
-	// GetCurrencyPrices returns all currency prices
-	GetCurrencyPrices(offset, limit uint32) (*types.CurrencyPrices, error)
 
 	// GetSwapAmount returns swap amount by request
 	GetSwapAmount(pairIndex, assetId int64, assetAmount string, isFrom bool) (*types.SwapAmount, error)
@@ -89,6 +83,12 @@ type ZkBNBQuerier interface {
 	// GetPair returns pair by pair index
 	GetPair(index uint32) (*types.Pair, error)
 
+	// GetAssetById returns asset by asset id
+	GetAssetById(id uint32) (*types.Asset, error)
+
+	// GetAssetBySymbol returns asset by asset symbol
+	GetAssetBySymbol(symbol string) (*types.Asset, error)
+
 	// GetAssets returns asset list
 	GetAssets(offset, limit uint32) (*types.Assets, error)
 
@@ -101,7 +101,7 @@ type ZkBNBQuerier interface {
 	// GetGasFee returns gas fee for asset
 	GetGasFee(assetId int64) (*big.Int, error)
 
-	// Search returns data type by queried info
+	// Search returns data type by queried keyword
 	Search(keyword string) (*types.Search, error)
 
 	// GetLayer2BasicInfo returns layer 2 basic info

--- a/client/l2_client.go
+++ b/client/l2_client.go
@@ -269,6 +269,48 @@ func (c *l2Client) GetGasFee(assetId int64) (*big.Int, error) {
 	return &price, nil
 }
 
+func (c *l2Client) GetAssetById(id uint32) (*types.Asset, error) {
+	resp, err := HttpClient.Get(c.endpoint +
+		fmt.Sprintf("/api/v1/asset?by=id&value=%d", id))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(string(body))
+	}
+	result := &types.Asset{}
+	if err := json.Unmarshal(body, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *l2Client) GetAssetBySymbol(symbol string) (*types.Asset, error) {
+	resp, err := HttpClient.Get(c.endpoint +
+		fmt.Sprintf("/api/v1/asset?by=symbol&value=%d", symbol))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(string(body))
+	}
+	result := &types.Asset{}
+	if err := json.Unmarshal(body, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (c *l2Client) GetAssets(offset, limit uint32) (*types.Assets, error) {
 	resp, err := HttpClient.Get(c.endpoint +
 		fmt.Sprintf("/api/v1/assets?offset=%d&limit=%d", offset, limit))
@@ -367,48 +409,6 @@ func (c *l2Client) GetAccountByPk(accountPk string) (*types.Account, error) {
 		return nil, fmt.Errorf(string(body))
 	}
 	result := &types.Account{}
-	if err := json.Unmarshal(body, result); err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func (c *l2Client) GetCurrencyPrice(symbol string) (*types.CurrencyPrice, error) {
-	resp, err := HttpClient.Get(c.endpoint +
-		fmt.Sprintf("/api/v1/currencyPrice?by=symbol&value=%s", symbol))
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(string(body))
-	}
-	result := &types.CurrencyPrice{}
-	if err := json.Unmarshal(body, result); err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func (c *l2Client) GetCurrencyPrices(offset, limit uint32) (*types.CurrencyPrices, error) {
-	resp, err := HttpClient.Get(c.endpoint +
-		fmt.Sprintf("/api/v1/currencyPrices?offset=%d&limit=%d", offset, limit))
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(string(body))
-	}
-	result := &types.CurrencyPrices{}
 	if err := json.Unmarshal(body, result); err != nil {
 		return nil, err
 	}

--- a/client/l2_client.go
+++ b/client/l2_client.go
@@ -292,7 +292,7 @@ func (c *l2Client) GetAssetById(id uint32) (*types.Asset, error) {
 
 func (c *l2Client) GetAssetBySymbol(symbol string) (*types.Asset, error) {
 	resp, err := HttpClient.Get(c.endpoint +
-		fmt.Sprintf("/api/v1/asset?by=symbol&value=%d", symbol))
+		fmt.Sprintf("/api/v1/asset?by=symbol&value=%s", symbol))
 	if err != nil {
 		return nil, err
 	}

--- a/client/l2_client_test.go
+++ b/client/l2_client_test.go
@@ -38,15 +38,15 @@ func TestGetCurrentHeight(t *testing.T) {
 	println("current height: ", height)
 }
 
-func TestGetCurrencyPrice(t *testing.T) {
+func TestGetAsset(t *testing.T) {
 	sdkClient := getSdkClient()
-	price, err := sdkClient.GetCurrencyPrice("BNB")
+	asset, err := sdkClient.GetAssetBySymbol("BNB")
 	if err != nil {
 		println(err.Error())
 		return
 	}
 
-	println("bnb price: ", price.Price)
+	println("bnb price: ", asset.Price)
 }
 
 func TestGetAccountNfts(t *testing.T) {

--- a/types/type.go
+++ b/types/type.go
@@ -6,10 +6,15 @@ type Status struct {
 }
 
 type AccountAsset struct {
-	Id       uint32 `json:"id"`
-	Name     string `json:"name"`
-	Balance  string `json:"balance"`
-	LpAmount string `json:"lp_amount"`
+	Id      uint32 `json:"id"`
+	Name    string `json:"name"`
+	Balance string `json:"balance"`
+	Price   string `json:"price"`
+}
+
+type AccountLp struct {
+	Index  uint32 `json:"index"`
+	Amount string `json:"amount"`
 }
 
 type Account struct {
@@ -19,6 +24,7 @@ type Account struct {
 	Pk     string          `json:"pk"`
 	Nonce  int64           `json:"nonce"`
 	Assets []*AccountAsset `json:"assets"`
+	Lps    []*AccountLp    `json:"lps"`
 }
 
 type SimpleAccount struct {
@@ -38,6 +44,7 @@ type Asset struct {
 	Decimals   uint32 `json:"decimals"`
 	Symbol     string `json:"symbol"`
 	Address    string `json:"address"`
+	Price      string `json:"price"`
 	IsGasAsset uint32 `json:"is_gas_asset"`
 }
 
@@ -86,17 +93,6 @@ type Layer2BasicInfo struct {
 	ContractAddresses         []ContractAddress `json:"contract_addresses"`
 }
 
-type CurrencyPrice struct {
-	Pair    string `json:"pair"`
-	AssetId uint32 `json:"asset_id"`
-	Price   string `json:"price"`
-}
-
-type CurrencyPrices struct {
-	Total          uint32           `json:"total"`
-	CurrencyPrices []*CurrencyPrice `json:"currency_prices"`
-}
-
 type GasFee struct {
 	GasFee string `json:"gas_fee"`
 }
@@ -126,8 +122,10 @@ type Pair struct {
 	AssetAId      uint32 `json:"asset_a_id"`
 	AssetAName    string `json:"asset_a_name"`
 	AssetAAmount  string `json:"asset_a_amount"`
+	AssetAPrice   string `json:"asset_a_price"`
 	AssetBId      uint32 `json:"asset_b_id"`
 	AssetBName    string `json:"asset_b_name"`
+	AssetBPrice   string `json:"asset_b_price"`
 	AssetBAmount  string `json:"asset_b_amount"`
 	FeeRate       int64  `json:"fee_rate"`
 	TreasuryRate  int64  `json:"treasury_rate"`
@@ -141,9 +139,11 @@ type Pairs struct {
 type LpValue struct {
 	AssetAId     uint32 `json:"asset_a_id"`
 	AssetAName   string `json:"asset_a_name"`
+	AssetAPrice  string `json:"asset_a_price"`
 	AssetAAmount string `json:"asset_a_amount"`
 	AssetBId     uint32 `json:"asset_b_id"`
 	AssetBName   string `json:"asset_b_name"`
+	AssetBPrice  string `json:"asset_b_price"`
 	AssetBAmount string `json:"asset_b_amount"`
 }
 


### PR DESCRIPTION
### Description

Remove `currencyPrice` `currencyPrices` apis;
Add `price` field in many related apis;

### Rationale

Make it easy for front-end developers to use.

### Example

NA

### Changes

Notable changes:
* l2 apis