### PR TITLE
feat(types): add `Size` for `Block`

### DIFF
--- a/types/type.go
+++ b/types/type.go
@@ -66,6 +66,7 @@ type Block struct {
 	VerifiedAt                      int64  `json:"verified_at"`
 	Txs                             []*Tx  `json:"txs"`
 	Status                          int64  `json:"status"`
+	Size                            uint16 `json:"size"`
 }
 
 type Blocks struct {


### PR DESCRIPTION
### Description

add `Size` for `type Block struct`

### Rationale
Sync l2 blocks from api server for FullNode, required block `Size` to create blocks into DB

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add `Size` member for `type Block struct`
* ...