### PR TITLE
feat: add totalAssetValue in GetAccount API response

### DIFF
--- a/types/type.go
+++ b/types/type.go
@@ -13,12 +13,13 @@ type AccountAsset struct {
 }
 
 type Account struct {
-	Status uint32          `json:"status"`
-	Index  int64           `json:"index"`
-	Name   string          `json:"name"`
-	Pk     string          `json:"pk"`
-	Nonce  int64           `json:"nonce"`
-	Assets []*AccountAsset `json:"assets"`
+	Status          uint32          `json:"status"`
+	Index           int64           `json:"index"`
+	Name            string          `json:"name"`
+	Pk              string          `json:"pk"`
+	Nonce           int64           `json:"nonce"`
+	Assets          []*AccountAsset `json:"assets"`
+	TotalAssetPrice string          `json:"total_asset_price"`
 }
 
 type SimpleAccount struct {

--- a/types/type.go
+++ b/types/type.go
@@ -13,13 +13,13 @@ type AccountAsset struct {
 }
 
 type Account struct {
-	Status           uint32          `json:"status"`
-	Index            int64           `json:"index"`
-	Name             string          `json:"name"`
-	Pk               string          `json:"pk"`
-	Nonce            int64           `json:"nonce"`
-	Assets           []*AccountAsset `json:"assets"`
-	TotalAssetAmount string          `json:"total_asset_amount"`
+	Status          uint32          `json:"status"`
+	Index           int64           `json:"index"`
+	Name            string          `json:"name"`
+	Pk              string          `json:"pk"`
+	Nonce           int64           `json:"nonce"`
+	Assets          []*AccountAsset `json:"assets"`
+	TotalAssetValue string          `json:"total_asset_value"`
 }
 
 type SimpleAccount struct {

--- a/types/type.go
+++ b/types/type.go
@@ -13,13 +13,13 @@ type AccountAsset struct {
 }
 
 type Account struct {
-	Status          uint32          `json:"status"`
-	Index           int64           `json:"index"`
-	Name            string          `json:"name"`
-	Pk              string          `json:"pk"`
-	Nonce           int64           `json:"nonce"`
-	Assets          []*AccountAsset `json:"assets"`
-	TotalAssetPrice string          `json:"total_asset_price"`
+	Status           uint32          `json:"status"`
+	Index            int64           `json:"index"`
+	Name             string          `json:"name"`
+	Pk               string          `json:"pk"`
+	Nonce            int64           `json:"nonce"`
+	Assets           []*AccountAsset `json:"assets"`
+	TotalAssetAmount string          `json:"total_asset_amount"`
 }
 
 type SimpleAccount struct {


### PR DESCRIPTION
### Description

Add totalAssetValue in GetAccount API response.

### Rationale

Account page need show the value

### Example

N/A

### Changes

N/A