### PR TITLE
feat: Implement GetExecutedTxs API

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -17,7 +17,8 @@ type ZkBNBClient interface {
 }
 
 type getTxOption struct {
-	Types []int64
+	Types    []int64
+	FromHash string
 }
 
 type GetTxOptionFunc func(*getTxOption)
@@ -25,6 +26,13 @@ type GetTxOptionFunc func(*getTxOption)
 func GetTxWithTypes(txTypes []int64) GetTxOptionFunc {
 	return func(o *getTxOption) {
 		o.Types = txTypes
+	}
+}
+
+// Get txs from the tx hash record
+func GetTxWithFromHash(hash string) GetTxOptionFunc {
+	return func(o *getTxOption) {
+		o.FromHash = hash
 	}
 }
 
@@ -64,6 +72,9 @@ type ZkBNBQuerier interface {
 
 	// GetPendingTxsByAccountName returns the pending txs by account name
 	GetPendingTxsByAccountName(accountName string, options ...GetTxOptionFunc) (total uint32, txs []*types.Tx, err error)
+
+	// GetPendingTxs returns the executed txs
+	GetExecutedTxs(offset, limit uint32, options ...GetTxOptionFunc) (total uint32, txs []*types.Tx, err error)
 
 	// GetAccountByName returns account (mainly pubkey) by account name
 	GetAccountByName(accountName string) (*types.Account, error)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bnb-chain/zkbnb-go-sdk
 go 1.18
 
 require (
-	github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220928090246-9a20106a2347
+	github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221026031758-e17661beb2af
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/ethereum/go-ethereum v1.10.17
 	github.com/stretchr/testify v1.7.2
@@ -19,6 +19,7 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rjeczalik/notify v0.9.1 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220928090246-9a20106a2347 h1:Dv+ztM5Bb8I2m3cf5WDYZZ+sFmNhWzNS41cxAx2AUrc=
-github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220928090246-9a20106a2347/go.mod h1:L1BEYSG945hwjJCtR5LUQ1pvRmydSsk9oU2d9YvoOrA=
+github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221026031758-e17661beb2af h1:CYTop6fqZ5HtvK9DdoSkljv1asM5sFDNCZA6D6F3yAw=
+github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221026031758-e17661beb2af/go.mod h1:TSIDCYcRZCCFnx/VOXFd9jb9EDnn4xRxfERK1zGwrrU=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/btcd/btcec/v2 v2.1.2/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=


### PR DESCRIPTION
### Description

Add API for `GET /executedTxs`

### Rationale

The difflayer of marketplace need the API to fetch transactions more earlier
For GET /pendingTxs, we can't get the executed result
For GET /txs, we can't get transactions that are not packed into blocks

### Example

`GET /executedTxs?offset=0&limit=10&from_hash=xxx`

Response
```
{
  "total": 10
  "txs": [
    ......,
  ]
}
```

### Changes

Notable changes:
* Add `GET /executedTxs` API