### PR TITLE
remove the fixed gas limit setting

### DIFF
--- a/client/l1_client.go
+++ b/client/l1_client.go
@@ -134,8 +134,7 @@ func (c *l1Client) getTransactor(value *big.Int) (*bind.TransactOpts, error) {
 	}
 
 	auth.Nonce = big.NewInt(int64(nonce))
-	auth.Value = value              // in wei
-	auth.GasLimit = uint64(5000000) // in units
+	auth.Value = value // in wei
 	auth.GasPrice = gasPrice
 	return auth, nil
 }


### PR DESCRIPTION
### Description

Remove the fixed gas limit setting in `l1_client.go`

### Rationale
In fact, in the base implementation, if the gas limit is not set, the gas limit will be set according to the estimated gas, so no need set the gas limit, and when the actual gas of the transaction exceeds the fixed value, the transaction will also fail
<img width="1641" alt="截屏2023-02-15 下午9 54 18" src="https://user-images.githubusercontent.com/24997729/219127234-6ad2d050-6c03-44a2-b568-3dafdbc2c740.png">

### Changes
<img width="1129" alt="截屏2023-02-15 下午9 57 49" src="https://user-images.githubusercontent.com/24997729/219127149-15fdfb92-427b-49b2-9aa0-850dc636e381.png">

